### PR TITLE
Let callers configure the CSVWriter

### DIFF
--- a/csv.go
+++ b/csv.go
@@ -36,15 +36,17 @@ var TagSeparator = ","
 
 var selfCSVWriter = DefaultCSVWriter
 
-// DefaultCSVWriter is the default SafeCSVWriter used to format CSV (cf. csv.NewWriter)
+//DefaultCSVWriter is the default SafeCSVWriter used to format CSV (cf. csv.NewWriter)
 func DefaultCSVWriter(out io.Writer) *SafeCSVWriter {
-	writer := NewSafeCSVWriter(csv.NewWriter(out))
+	csvWriter := csv.NewWriter(out)
 
 	// As only one rune can be defined as a CSV separator, we are going to trim
 	// the custom tag separator and use the first rune.
 	if runes := []rune(strings.TrimSpace(TagSeparator)); len(runes) > 0 {
-		writer.Comma = runes[0]
+		csvWriter.Comma = runes[0]
 	}
+
+	writer := NewSafeCSVWriter(csvWriter)
 
 	return writer
 }
@@ -114,6 +116,12 @@ func MarshalBytes(in interface{}) (out []byte, err error) {
 // Marshal returns the CSV in writer from the interface.
 func Marshal(in interface{}, out io.Writer) (err error) {
 	writer := getCSVWriter(out)
+	return writeTo(writer, in, false)
+}
+
+// A version of Marshal that accepts a CSVWriter as an interface
+func MarshalWithCSVWriter(in interface{}, csvWriter CSVWriter) error {
+	writer := NewSafeCSVWriter(csvWriter)
 	return writeTo(writer, in, false)
 }
 

--- a/encode.go
+++ b/encode.go
@@ -60,7 +60,7 @@ func writeFromChan(writer *SafeCSVWriter, c <-chan interface{}) error {
 		}
 	}
 	writer.Flush()
-	return writer.Error()
+	return writer.Writer.Error()
 }
 
 type headersToOmit map[string]int
@@ -144,7 +144,7 @@ func writeTo(writer *SafeCSVWriter, in interface{}, omitHeaders bool) error {
 		}
 	}
 	writer.Flush()
-	return writer.Error()
+	return writer.Writer.Error()
 }
 
 func ensureStructOrPtr(t reflect.Type) error {

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,3 @@
 module github.com/mamont1971/gocsv
+
+go 1.13

--- a/safe_csv.go
+++ b/safe_csv.go
@@ -2,16 +2,22 @@ package gocsv
 
 //Wraps around SafeCSVWriter and makes it thread safe.
 import (
-	"encoding/csv"
 	"sync"
 )
 
 type SafeCSVWriter struct {
-	*csv.Writer
+	Writer CSVWriter
 	m sync.Mutex
 }
 
-func NewSafeCSVWriter(original *csv.Writer) *SafeCSVWriter {
+type CSVWriter interface {
+	Error() error
+	Flush()
+	Write(record []string) error
+	WriteAll(records [][]string) error
+}
+
+func NewSafeCSVWriter(original CSVWriter) *SafeCSVWriter {
 	return &SafeCSVWriter{
 		Writer: original,
 	}

--- a/safe_csv.go
+++ b/safe_csv.go
@@ -14,7 +14,6 @@ type CSVWriter interface {
 	Error() error
 	Flush()
 	Write(record []string) error
-	WriteAll(records [][]string) error
 }
 
 func NewSafeCSVWriter(original CSVWriter) *SafeCSVWriter {


### PR DESCRIPTION
In this commit:
- Adds the ability for the caller to configure the CSVWriter that they want to use for the Marshal function, as opposed to only being able to use the default csv.Writer